### PR TITLE
Fix building of ggmorse.lib with MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,6 @@ option(GGMORSE_SUPPORT_SDL2             "ggmorse: support for libSDL2" ${GGMORSE
 
 option(GGMORSE_BUILD_TESTS              "ggmorse: build examples" ${GGMORSE_STANDALONE})
 option(GGMORSE_BUILD_EXAMPLES           "ggmorse: build examples" ${GGMORSE_STANDALONE})
-option(GGMORSE_BUILD                    "ggmorse: build" ON)
 
 option(GGMORSE_MALLOC_COUNT             "ggmorse: count memory allocations" OFF)
 

--- a/include/ggmorse/ggmorse.h
+++ b/include/ggmorse/ggmorse.h
@@ -1,7 +1,7 @@
 #ifndef GGMORSE_H
 #define GGMORSE_H
 
-#ifdef BUILD_SHARED_LIBS
+#ifdef GGMORSE_SHARED
 #    ifdef _WIN32
 #        ifdef GGMORSE_BUILD
 #            define GGMORSE_API __declspec(dllexport)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -20,6 +20,11 @@ if (BUILD_SHARED_LIBS)
     target_compile_definitions(${TARGET} PUBLIC
         GGMORSE_SHARED
         )
+    if (MSVC)
+        target_compile_definitions(${TARGET} PUBLIC
+            GGMORSE_BUILD
+            )
+    endif()
 endif()
 
 if (MINGW)


### PR DESCRIPTION
In ggmorse.h, revert to GGMORSE_SHARED which is defined in src/CMakeLists.txt. BUILD_SHARED_LIBS is only defined in cmake namespace, not as a C preprocessor macro.

Define GGMORSE_BUILD for MSVC, so that __declspec(dllexport) is used when building the dll rather than __declspec(dllimport). 

Remove option GGMORSE_BUILD which doesn't appear to do anything. (cmake doesn't automatically define C proprocessor macros based on cmake options, as far as I can see).

